### PR TITLE
fix clojure tests

### DIFF
--- a/contrib/clojure-package/test/good-test-ndarray-api.clj
+++ b/contrib/clojure-package/test/good-test-ndarray-api.clj
@@ -106,7 +106,7 @@
   
   
   
-  Defined in src/operator/nn/batch_norm.cc:L574
+  Defined in src/operator/nn/batch_norm.cc:L572
   
   `data`: Input data to batch normalization
   `gamma`: gamma array

--- a/contrib/clojure-package/test/good-test-symbol-api.clj
+++ b/contrib/clojure-package/test/good-test-symbol-api.clj
@@ -119,7 +119,7 @@
   
   
   
-  Defined in src/operator/nn/batch_norm.cc:L574
+  Defined in src/operator/nn/batch_norm.cc:L572
   
   `data`: Input data to batch normalization (optional)
   `gamma`: gamma array (optional)


### PR DESCRIPTION
This fixes the Clojure tests that are checking the generated code and was off by the documentation.

If it happens again these are the steps to fix the test in the Clojure package:

-  cd `contrib/clojure-package` 
- run `lein test` (You mush have https://leiningen.org/ installed)
- For the failed tests in the generator: cd `test` 
- cp `test-ndarray-api.clj` to `good-test-ndarray-api.clj`
- cp `test-symbol-api.clj` to `good-test-symbol-api.clj`
- run `lein test` to check that the failures have been resolved.

